### PR TITLE
Bug/Build fix for iOS 26

### DIFF
--- a/UIImageColors.xcodeproj/project.pbxproj
+++ b/UIImageColors.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 				TargetAttributes = {
 					035BC83C1DAB9FED006CA9BE = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = 5CM2SRJAY7;
+						DevelopmentTeam = DPE4LURAUZ;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -231,6 +231,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -421,18 +422,19 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5CM2SRJAY7;
+				DEVELOPMENT_TEAM = DPE4LURAUZ;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.jathu.UIImageColors;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -443,17 +445,18 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5CM2SRJAY7;
+				DEVELOPMENT_TEAM = DPE4LURAUZ;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.jathu.UIImageColors;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/UIImageColors.xcodeproj/project.pbxproj
+++ b/UIImageColors.xcodeproj/project.pbxproj
@@ -428,7 +428,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.jathu.UIImageColors;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -451,7 +451,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.jathu.UIImageColors;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/UIImageColors.xcodeproj/xcshareddata/xcschemes/UIImageColors.xcscheme
+++ b/UIImageColors.xcodeproj/xcshareddata/xcschemes/UIImageColors.xcscheme
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:UIImageColors.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Fix 3 issues with the update of Xcode 26:

1. We had error:

```
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "Headers/UIImageColors.h"
        ^
/Users/marc/Fabulous/repoReview/fabulous-ios/fabulous-ios/Carthage/Checkouts/UIImageColors/UIImageColors/Sources/UIImageColors.h:10:13: error: 'Appkit/AppKit.h' file not found
    #import <Appkit/AppKit.h>
            ^
<unknown>:0: error: could not build Objective-C module 'UIImageColors'
```

Error is happening [here](https://github.com/thefabulous/UIImageColors/blob/56014e206253b510c502e7a04c0f3a994f30b79e/UIImageColors/Sources/UIImageColors.h#L9).
We should not use anymore `TARGET_OS_MAC` (see answer [here](https://stackoverflow.com/questions/12132933/preprocessor-macro-for-os-x-targets)) as it's also valid for iOS.
It's an old thing, but maybe iOS 26 is more picky 🤷‍♂️
Now we should use `TARGET_OS_OSX`.
But anyway, we were using release 2.1.0, and in master, we only import iOS: https://github.com/thefabulous/UIImageColors/blob/0a83dea037510f04be776954814021eabe8295cd/Sources/UIImageColors.h#L9
So issue is fixed updating to master (this branch was created from master)

2. Issue:

```
/Users/marc/Fabulous/repoReview/fabulous-ios/fabulous-ios/Carthage/Checkouts/UIImageColors/UIImageColors.xcodeproj: warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 12.0 to 26.0.99. (in target 'UIImageColors' from project 'UIImageColors')
```

Updated to 17.0

3. Issue:

```
error: SWIFT_VERSION '3.0' is unsupported, supported versions are: 4.0, 4.2, 5.0, 6.0. (in target 'UIImageColors' from project 'UIImageColors')
```

Updated to Swift 5.0